### PR TITLE
Handle returning promises with async.

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -19,14 +19,22 @@ export default function(fn) {
       return invocation.isFinished;
     }
   };
+
   function wrapped() {
-    run(invocation.fn);
-    invocation.isFinished = true;
-    delete stateMap[invocation.id];
+    let result = run(invocation.fn);
+
+    return Ember.RSVP.resolve(result)
+      .then(() => {
+        invocation.isFinished = true;
+
+        delete stateMap[invocation.id];
+      });
   }
+
   if (hasTest) {
     Test.registerWaiter(invocation.waiter);
   }
+
   stateMap[invocation.id] = invocation;
   wrapped.__callback_guid = invocation.id;
   return wrapped;

--- a/tests/acceptance/async-callback-test.js
+++ b/tests/acceptance/async-callback-test.js
@@ -10,9 +10,26 @@ test('Ember.run.later()', function(assert) {
     assert.equal(find('.status').text().trim(), 'Async ran');
   });
 });
-test('callback() wrapped', function(assert) {
+
+test('sync callback()', function(assert) {
   visit('/');
   click('.run-callback');
+  andThen(() => {
+    assert.equal(find('.status').text().trim(), 'Async ran');
+  });
+});
+
+test('async callback()', function(assert) {
+  visit('/');
+  click('.run-callback-async');
+  andThen(() => {
+    assert.equal(find('.status').text().trim(), 'Async ran');
+  });
+});
+
+test('async callback()', function(assert) {
+  visit('/');
+  click('.run-callback-async');
   andThen(() => {
     assert.equal(find('.status').text().trim(), 'Async ran');
   });

--- a/tests/dummy/app/components/component-with-async-action.js
+++ b/tests/dummy/app/components/component-with-async-action.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 import callback from 'ember-run-callback';
 
+const { run } = Ember;
+
 export default Ember.Component.extend({
 
   asyncDidRun: false,
@@ -18,6 +20,20 @@ export default Ember.Component.extend({
           resolve();
         });
       }), 500);
+    },
+
+    runCallbackWithAsync() {
+      setTimeout(callback(() => {
+        return new Ember.RSVP.Promise((resolve) => {
+          setTimeout(() => {
+            run(() => {
+              this.set('asyncDidRun', true);
+
+              resolve();
+            });
+          }, 500);
+        });
+      }));
     }
   }
 

--- a/tests/dummy/app/templates/components/component-with-async-action.hbs
+++ b/tests/dummy/app/templates/components/component-with-async-action.hbs
@@ -1,5 +1,6 @@
 <button class='run-later' {{action 'runLater'}}>Ember.run.later()</button>
 <button class='run-callback' {{action 'runCallback'}}>callback()</button>
+<button class='run-callback-async' {{action 'runCallbackWithAsync'}}>callback() with async</button>
 
 <div class='status'>
   {{if asyncDidRun 'Async ran' 'Async did not run'}}


### PR DESCRIPTION
The waiter was not properly handling `fn` returning a promise that had async. This updates to ensure that any returned promise is resolved before marking the waiter as completed.

---

The existing tests were using async (via `setTimeout`) to kick off the callback, but since the promise used was resolving synchronously in the `Ember.RSVP.Promise` constructor true async was not being tested.
