### PR TITLE
Ensure callback is invoked immediately.

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -22,18 +22,23 @@ export default function(fn) {
     run(invocation.fn);
     invocation.isFinished = true;
     delete stateMap[invocation.id];
+
+    return invocation.id;
   }
   Test.registerWaiter(invocation.waiter);
   stateMap[invocation.id] = invocation;
   wrapped.__callback_guid = invocation.id;
-  return wrapped;
+
+  return wrapped();
 }
 
-export function cancel(wrapped) {
-  if (wrapped && stateMap[wrapped.__callback_guid]) {
-    let callback = stateMap[wrapped.__callback_guid];
+export function cancel(id) {
+  let callback = stateMap[id];
+
+  if (callback) {
     Test.unregisterWaiter(callback.waiter);
-    callback.fn = Ember.RSVP.resolve;
-    stateMap.delete(wrapped);
+    callback.fn = function() { };
+
+    delete stateMap[id];
   }
 }

--- a/tests/acceptance/async-callback-test.js
+++ b/tests/acceptance/async-callback-test.js
@@ -10,10 +10,19 @@ test('Ember.run.later()', function(assert) {
     assert.equal(find('.status').text().trim(), 'Async ran');
   });
 });
+
 test('callback() wrapped', function(assert) {
   visit('/');
   click('.run-callback');
   andThen(() => {
     assert.equal(find('.status').text().trim(), 'Async ran');
+  });
+});
+
+test('callback() & cancel()', function(assert) {
+  visit('/');
+  click('.run-callback-and-cancel');
+  andThen(() => {
+    assert.equal(find('.status').text().trim(), 'Async did not run');
   });
 });

--- a/tests/dummy/app/components/component-with-async-action.js
+++ b/tests/dummy/app/components/component-with-async-action.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import callback from 'ember-run-callback';
+import callback, { cancel } from 'ember-run-callback';
 
 export default Ember.Component.extend({
 
@@ -12,12 +12,31 @@ export default Ember.Component.extend({
       }, 500);
     },
     runCallback() {
-      setTimeout(callback(() => {
+      callback(() => {
         return new Ember.RSVP.Promise((resolve) => {
           this.set('asyncDidRun', true);
           resolve();
         });
-      }), 500);
+      });
+    },
+
+    runAndCancel() {
+      let foo = callback(() => {
+        return new Ember.RSVP.Promise((resolve) => {
+          setTimeout(() => {
+
+            if (!this.isDestroyed) {
+              this.set('asyncDidRun', true);
+            }
+
+            resolve();
+          }, 1000);
+        });
+      });
+
+      setTimeout(() => {
+        cancel(foo);
+      }, 250);
     }
   }
 

--- a/tests/dummy/app/templates/components/component-with-async-action.hbs
+++ b/tests/dummy/app/templates/components/component-with-async-action.hbs
@@ -1,5 +1,6 @@
 <button class='run-later' {{action 'runLater'}}>Ember.run.later()</button>
 <button class='run-callback' {{action 'runCallback'}}>callback()</button>
+<button class='run-callback-and-cancel' {{action 'runAndCancel'}}>callback() & cancel()</button>
 
 <div class='status'>
   {{if asyncDidRun 'Async ran' 'Async did not run'}}


### PR DESCRIPTION
Prior to this change we would add a test waiter that would not complete until the wrapped callback was invoked, but we would never actually invoke it.

The majority of other `run.*` callback methods (with the exception of `Ember.run.bind`) will always ensure that the callback provided is invoked (i.e. `Ember.run`, `Ember.run.next`, `Ember.run.later`, etc).

This changes to ensure that the callback is invoked.

I could easily see where we might want to ensure that we always invoke in the next tick (to ensure an async paradigm), but I'm not certain...

---

I opened this PR as a conversation starter...
